### PR TITLE
Revert "Use clues to infer which letters in previous guesses may have been in word"

### DIFF
--- a/src/About.tsx
+++ b/src/About.tsx
@@ -1,4 +1,4 @@
-import { Clue, CluedLetter } from "./clue";
+import { Clue } from "./clue";
 import { Row, RowState } from "./Row";
 import { gameName, maxGuesses } from "./util";
 
@@ -22,13 +22,12 @@ export function About() {
       <Row
         rowState={RowState.LockedIn}
         wordLength={5}
-        letterInfo={new Map<string, CluedLetter>()}
         cluedLetters={[
-          { clue: Clue.Absent, letter: "h", index: -1 },
-          { clue: Clue.Absent, letter: "o", index: -1 },
-          { clue: Clue.Absent, letter: "u", index: -1 },
-          { clue: Clue.Absent, letter: "n", index: -1 },
-          { clue: Clue.Absent, letter: "d", index: -1 },
+          { clue: Clue.Absent, letter: "h" },
+          { clue: Clue.Absent, letter: "o" },
+          { clue: Clue.Absent, letter: "u" },
+          { clue: Clue.Absent, letter: "n" },
+          { clue: Clue.Absent, letter: "d" },
         ]}
       />
       <p>
@@ -37,13 +36,12 @@ export function About() {
       <Row
         rowState={RowState.LockedIn}
         wordLength={5}
-        letterInfo={new Map<string, CluedLetter>()}
         cluedLetters={[
-          { clue: Clue.Absent, letter: "f", index: -1 },
-          { clue: Clue.Absent, letter: "l", index: -1 },
-          { clue: Clue.Absent, letter: "a", index: -1 },
-          { clue: Clue.Elsewhere, letter: "s", index: -1 },
-          { clue: Clue.Absent, letter: "h", index: -1 },
+          { clue: Clue.Absent, letter: "f" },
+          { clue: Clue.Absent, letter: "l" },
+          { clue: Clue.Absent, letter: "a" },
+          { clue: Clue.Elsewhere, letter: "s" },
+          { clue: Clue.Absent, letter: "h" },
         ]}
       />
       <p>
@@ -53,13 +51,12 @@ export function About() {
       <Row
         rowState={RowState.LockedIn}
         wordLength={5}
-        letterInfo={new Map<string, CluedLetter>()}
         cluedLetters={[
-          { clue: Clue.Correct, letter: "s", index: 0 },
-          { clue: Clue.Correct, letter: "t", index: 1 },
-          { clue: Clue.Correct, letter: "e", index: 2 },
-          { clue: Clue.Elsewhere, letter: "r", index: -1 },
-          { clue: Clue.Absent, letter: "n", index: -1 },
+          { clue: Clue.Correct, letter: "s" },
+          { clue: Clue.Correct, letter: "t" },
+          { clue: Clue.Correct, letter: "e" },
+          { clue: Clue.Elsewhere, letter: "r" },
+          { clue: Clue.Absent, letter: "n" },
         ]}
       />
       <p>
@@ -73,13 +70,12 @@ export function About() {
       <Row
         rowState={RowState.LockedIn}
         wordLength={5}
-        letterInfo={new Map<string, CluedLetter>()}
         cluedLetters={[
-          { clue: Clue.Correct, letter: "s", index: 0 },
-          { clue: Clue.Correct, letter: "t", index: 1 },
-          { clue: Clue.Correct, letter: "e", index: 2 },
-          { clue: Clue.Correct, letter: "e", index: 3 },
-          { clue: Clue.Correct, letter: "r", index: 4 },
+          { clue: Clue.Correct, letter: "s" },
+          { clue: Clue.Correct, letter: "t" },
+          { clue: Clue.Correct, letter: "e" },
+          { clue: Clue.Correct, letter: "e" },
+          { clue: Clue.Correct, letter: "r" },
         ]}
         annotation={"Got it!"}
       />

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Row, RowState } from "./Row";
 import dictionary from "./dictionary.json";
-import { Clue, clue, CluedLetter, describeClue, expectedLetterInfo, obscureClue, violation } from "./clue";
+import { Clue, clue, describeClue, obscureClue, violation } from "./clue";
 import { Keyboard } from "./Keyboard";
 import targetList from "./targets.json";
 import {
@@ -101,48 +101,6 @@ function Game(props: GameProps) {
     for (let i = 1; i < gameNumber; i++) randomTarget(wordLength);
     return challenge || randomTarget(wordLength);
   });
-
-  const getLetterInfo = (target: string, guesses: string[], letterInfo: Map<string, CluedLetter>) => {
-    for (const guess of guesses.slice().reverse()) {
-      const cluedLetters = clue(guess, target);
-      const obscuredClue = obscureClue(cluedLetters);
-      const expectedInfo = expectedLetterInfo(guess, letterInfo);
-      // if we only get the expected number of correct letters, none of the others are in the target
-      if ((obscuredClue.get(Clue.Correct) ?? 0) + (obscuredClue.get(Clue.Elsewhere) ?? 0) ===
-        (expectedInfo.get(Clue.Correct) ?? 0) + (expectedInfo.get(Clue.Elsewhere) ?? 0)) {
-        for (const { clue, letter } of cluedLetters) {
-          if ((letterInfo.get(letter)?.clue ?? Clue.Unknown) === Clue.Unknown) {
-            letterInfo.set(letter, { clue: Clue.Absent, letter, index: -1 });
-          }
-        }
-      }
-      // if all the previously unknown letters in the guess are in the target
-      if ((expectedInfo.get(Clue.Unknown) ?? 0) + (expectedInfo.get(Clue.Correct) ?? 0) + (expectedInfo.get(Clue.Elsewhere) ?? 0) ===
-        (obscuredClue.get(Clue.Correct) ?? 0) + (obscuredClue.get(Clue.Elsewhere) ?? 0)) {
-        for (const { clue, letter } of cluedLetters) {
-          if ((letterInfo.get(letter)?.clue ?? Clue.Unknown) === Clue.Unknown) {
-            letterInfo.set(letter, { clue: Clue.Elsewhere, letter, index: -1 });
-          }
-        }
-      }
-      // if all the previously unknown letters in the guess are in the correct spot
-      if ((expectedInfo.get(Clue.Unknown) ?? 0) + (expectedInfo.get(Clue.Correct) ?? 0) + (expectedInfo.get(Clue.Elsewhere) ?? 0) ===
-        (obscuredClue.get(Clue.Correct) ?? 0)) {
-        for (const { clue, letter, index } of cluedLetters) {
-          if ((letterInfo.get(letter)?.clue ?? Clue.Unknown) === Clue.Unknown || (letterInfo.get(letter)?.clue ?? Clue.Unknown) === Clue.Elsewhere) {
-            letterInfo.set(letter, { clue: Clue.Correct, letter, index });
-          }
-        }
-      }
-    }
-    return letterInfo;
-  };
-  const [letterInfo, setLetterInfo] = useState<Map<string, CluedLetter>>(
-    getLetterInfo(target, guesses,
-      getLetterInfo(target, guesses, new Map<string, CluedLetter>())
-    )
-  );
-
   const [gameState, setGameState] = useState(
     guesses.includes(target)
       ? GameState.Won
@@ -286,14 +244,21 @@ function Game(props: GameProps) {
     };
   }, [currentGuess, gameState]);
 
-  useEffect(() => setLetterInfo(getLetterInfo(target, guesses, letterInfo)), [guesses]);
-  useEffect(() => setLetterInfo(getLetterInfo(target, guesses, new Map<string, CluedLetter>())), [target]);
+  let letterInfo = new Map<string, Clue>();
   const tableRows = Array(props.maxGuesses)
     .fill(undefined)
     .map((_, i) => {
       const guess = [...guesses, currentGuess][i] ?? "";
       const cluedLetters = clue(guess, target);
+      const obscuredClue = obscureClue(cluedLetters);
       const lockedIn = i < guesses.length;
+      if (lockedIn) {
+        if (!obscuredClue.has(Clue.Correct) && !obscuredClue.has(Clue.Elsewhere)) {
+          for (const { clue, letter } of cluedLetters) {
+            letterInfo.set(letter, Clue.Absent);
+          }
+        }
+      }
       return (
         <Row
           key={i}
@@ -306,10 +271,10 @@ function Game(props: GameProps) {
                 : RowState.Pending
           }
           cluedLetters={cluedLetters}
-          letterInfo={letterInfo}
         />
       );
     });
+
   return (
     <div className="Game" style={{ display: props.hidden ? "none" : "block" }}>
       <table

--- a/src/Keyboard.tsx
+++ b/src/Keyboard.tsx
@@ -1,8 +1,8 @@
-import { Clue, clueClass, CluedLetter } from "./clue";
+import { Clue, clueClass } from "./clue";
 
 interface KeyboardProps {
   layout: string;
-  letterInfo: Map<string, CluedLetter>;
+  letterInfo: Map<string, Clue>;
   onKey: (key: string) => void;
 }
 
@@ -21,7 +21,7 @@ export function Keyboard(props: KeyboardProps) {
         <div key={i} className="Game-keyboard-row">
           {row.map((label, j) => {
             let className = "Game-keyboard-button";
-            const clue = props.letterInfo.get(label)?.clue ?? Clue.Unknown;
+            const clue = props.letterInfo.get(label);
             if (clue !== undefined) {
               className += " " + clueClass(clue);
             }

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -11,7 +11,6 @@ interface RowProps {
   wordLength: number;
   cluedLetters: CluedLetter[];
   annotation?: string;
-  letterInfo: Map<string, CluedLetter>;
 }
 
 export function Row(props: RowProps) {
@@ -27,17 +26,19 @@ export function Row(props: RowProps) {
   }
 
   const letterDivs = props.cluedLetters
-    .concat(Array(props.wordLength).fill({ clue: Clue.Absent, letter: "", index: -1 }))
+    .concat(Array(props.wordLength).fill({ clue: Clue.Absent, letter: "" }))
     .slice(0, props.wordLength)
-    .map(({ clue, letter, index }, i) => {
+    .map(({ clue, letter }, i) => {
       let letterClass = "Row-letter";
       if (isLockedIn && clue !== undefined) {
-        const thisLetterInfo = props.letterInfo.get(letter);
-        const letterInfoClue = thisLetterInfo?.clue ?? Clue.Unknown;
-        if (letterInfoClue !== Clue.Correct || thisLetterInfo?.index === i) {
-          letterClass += " " + clueClass(letterInfoClue);
-        } else {
+        if (numberElsewhere === props.cluedLetters.length) {
           letterClass += " " + clueClass(Clue.Elsewhere);
+        } else if (numberCorrect === props.cluedLetters.length) {
+          letterClass += " " + clueClass(Clue.Correct);
+        } else if (numberCorrect + numberElsewhere === 0) {
+          letterClass += " " + clueClass(Clue.Absent);
+        } else {
+          letterClass += " " + clueClass(Clue.Unknown);
         }
       }
       return (

--- a/src/clue.ts
+++ b/src/clue.ts
@@ -1,4 +1,4 @@
-import { ValidationLevel } from "./util";
+import { ValidationLevel, englishNumbers, ordinal } from "./util";
 
 export enum Clue {
   Unknown,
@@ -8,9 +8,8 @@ export enum Clue {
 }
 
 export interface CluedLetter {
-  clue: Clue;
+  clue?: Clue;
   letter: string;
-  index: number;
 }
 
 export function clue(word: string, target: string): CluedLetter[] {
@@ -20,20 +19,16 @@ export function clue(word: string, target: string): CluedLetter[] {
       elusive.push(letter);
     }
   });
-  return word.split("").map((letter, index) => {
+  return word.split("").map((letter, i) => {
     let j: number;
-    if (target[index] === letter) {
-      return { clue: Clue.Correct, letter, index };
+    if (target[i] === letter) {
+      return { clue: Clue.Correct, letter };
     } else if ((j = elusive.indexOf(letter)) > -1) {
       // "use it up" so we don't clue at it twice
       elusive[j] = "";
-      return {
-        clue: Clue.Elsewhere, letter, index: -1
-      };
+      return { clue: Clue.Elsewhere, letter };
     } else {
-      return {
-        clue: Clue.Absent, letter, index: -1
-      };
+      return { clue: Clue.Absent, letter };
     }
   });
 }
@@ -41,16 +36,6 @@ export function clue(word: string, target: string): CluedLetter[] {
 export function obscureClue(cluedLetters: CluedLetter[]): Map<Clue, number> {
   let obscured = new Map<Clue, number>();
   for (const { clue, letter } of cluedLetters) {
-    if (clue === undefined) continue;
-    obscured.set(clue, 1 + (obscured.get(clue) ?? 0));
-  }
-  return obscured;
-}
-
-export function expectedLetterInfo(guess: string, letterInfo: Map<string, CluedLetter>): Map<Clue, number> {
-  let obscured = new Map<Clue, number>();
-  for (const letter of guess) {
-    const clue = letterInfo.get(letter)?.clue ?? Clue.Unknown;
     if (clue === undefined) continue;
     obscured.set(clue, 1 + (obscured.get(clue) ?? 0));
   }


### PR DESCRIPTION
Reverts tjasz/obscurdle#1

The implementation in #1 is still buggy. It doesn't always apply new info until after a refresh. The inferences about letters can stick around after a new game is started with a different word, even though they no longer apply. The previous state (where it only made inferences if all letters were absent, elsewhere, or correct) was better.